### PR TITLE
Docs: Add control loop description and diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,43 @@ This project describes the wiring and control of a digital Märklin motor using 
 
 ## Control System
 
-This project uses a **closed-loop control system** to regulate the motor's speed. A non-blocking, software-based PWM system is used to control the motor. This allows for precise timing of back-EMF (BEMF) measurements during the "off" phase of the PWM cycle, providing an accurate measurement of the motor's speed. A proportional controller then adjusts the PWM duty cycle to match the target speed. The entire control loop is managed with non-blocking timers for smooth operation.
+This project uses a **closed-loop control system** to regulate the motor's speed. The system is based on measuring the motor's back-EMF (BEMF) to determine its actual speed and then adjusting the power delivered to the motor via Pulse Width Modulation (PWM) to match a target speed.
+
+The control loop operates as follows:
+
+1.  **Speed Measurement (BEMF Sensing):**
+    *   To measure the BEMF, the motor must be temporarily disconnected from the power source. This is achieved by putting the motor driver (H-Bridge) into a high-impedance state, effectively letting the motor "coast" for a very short period.
+    *   During this coasting phase, the motor acts as a generator, producing a voltage proportional to its speed. This voltage is the BEMF.
+    *   The BEMF is read as a differential voltage between the two motor terminals (`OutA` and `OutB`) using the RP2040's ADC pins.
+    *   As the motor turns, the BEMF signal forms a wave. The system counts the peaks (commutation pulses) of this wave over a fixed time interval (100ms) to calculate the motor's speed in pulses per second (PPS).
+
+2.  **Proportional Controller:**
+    *   A proportional (P) controller is used to adjust the motor's speed.
+    *   It first calculates the `error` by subtracting the measured speed from the `target_speed`.
+    *   It then calculates a new PWM duty cycle by adding a correction factor to the target speed. This correction is the `error` multiplied by a proportional gain constant (`Kp`).
+    *   The formula is: `PWM_Duty_Cycle = Target_Speed + (Kp * Error)`
+    *   The result is constrained to valid PWM values (0-255).
+
+3.  **Actuation (Software PWM):**
+    *   A non-blocking, software-based PWM signal with a frequency of 1kHz is used to drive the motor.
+    *   The BEMF measurement is strategically timed to occur during the "off" phase of each PWM cycle, ensuring that the measurement is not affected by the driving voltage.
+
+### Control Loop Diagram
+
+```
+            +------------------+     +------------------+     +------------------+
+Set-point   |                  |     |                  |     |                  |
+(Target ---->|    Controller    |----->|      Motor     |----->|      Motor     |----> Actual
+ Speed)     | (P-Regler)       | PWM |      Driver      | PWM |                  |      Speed
+            |                  |     |    (BDR-6133)    |     |                  |
+            +------------------+     +------------------+     +------------------+
+                  ^                                                   |
+                  |                                                   |
+                  | Error                                             | BEMF
+                  |                                                   |
+                  +---------------------------------------------------+
+                                        Feedback
+```
 
 ## Wiring
 


### PR DESCRIPTION
Adds a detailed description of the closed-loop control system to the README.md.

Includes an explanation of BEMF sensing, the proportional controller, and the software PWM implementation. Also adds an ASCII art diagram to visualize the control loop.