### PR TITLE
feat(ci): Update and correct the release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -30,8 +32,6 @@ jobs:
 
       - name: Upload Release Asset
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           files: .pio/build/seeed_xiao_rp2040/firmware.uf2


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to correctly build and upload the UF2 firmware file as a release asset.

- Adds `permissions: contents: write` to the build job, which is required for the `softprops/action-gh-release` action to create a release and upload assets.
- Updates `actions/checkout` to `v5`, `actions/setup-python` to `v5`, and `softprops/action-gh-release` to `v2` to use the latest versions of these actions.