### PR TITLE
feat: Implement detailed motor test pattern

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,8 +9,6 @@ const int statusLedPin = LED_BUILTIN; // Status LED
 
 // Motor control parameters
 const int max_speed = 255;
-const int half_speed = 127;
-const int ramp_duration_ms = 3000;
 
 // Proportional control gain
 const float Kp = 0.1;
@@ -25,17 +23,18 @@ bool last_bemf_state = false;
 const int pwm_frequency = 1000; // Hz
 const long pwm_period_us = 1000000 / pwm_frequency;
 
-// Non-blocking timers and state variables
+// --- State Machine ---
+enum MotorState { RAMP_UP, COAST_HIGH, RAMP_DOWN, COAST_LOW, STOP };
+MotorState current_state = RAMP_UP;
+unsigned long state_start_ms = 0;
 unsigned long last_ramp_update_ms = 0;
-unsigned long last_pwm_cycle_us = 0;
-unsigned long direction_change_start_ms = 0;
-int ramp_step_delay_ms = ramp_duration_ms / half_speed;
+const int ramp_step_delay_ms = 20; // Time between speed increments/decrements
 
+// Motor and PWM state
 int target_speed = 0;
 int current_pwm = 0;
 bool forward = true;
-bool ramping_up = true;
-bool in_direction_change_delay = false;
+unsigned long last_pwm_cycle_us = 0;
 bool bemf_measured_this_cycle = false;
 
 void setup() {
@@ -70,21 +69,27 @@ void update_motor_pwm() {
 }
 
 void update_status_light() {
-  unsigned long current_millis = millis();
-
-  if (in_direction_change_delay) {
-    // Fast blink (100ms interval)
-    digitalWrite(statusLedPin, (current_millis / 100) % 2);
-  } else if (!ramping_up && target_speed > 0) {
-    // Slow blink (500ms interval)
-    digitalWrite(statusLedPin, (current_millis / 500) % 2);
-  } else if (target_speed > 0) {
-    // Solid ON
-    digitalWrite(statusLedPin, HIGH);
-  } else {
-    // Solid OFF
-    digitalWrite(statusLedPin, LOW);
-  }
+    unsigned long current_millis = millis();
+    switch (current_state) {
+        case RAMP_UP:
+            digitalWrite(statusLedPin, HIGH); // Solid ON during ramp up
+            break;
+        case RAMP_DOWN:
+            // Slow blink (500ms interval)
+            digitalWrite(statusLedPin, (current_millis / 500) % 2);
+            break;
+        case COAST_HIGH:
+        case COAST_LOW:
+            digitalWrite(statusLedPin, HIGH); // Solid ON during coasting
+            break;
+        case STOP:
+            // Fast blink (100ms interval) during stop
+            digitalWrite(statusLedPin, (current_millis / 100) % 2);
+            break;
+        default:
+            digitalWrite(statusLedPin, LOW); // Off otherwise
+            break;
+    }
 }
 
 void loop() {
@@ -106,45 +111,74 @@ void loop() {
     last_speed_calc_ms = current_millis;
   }
 
-  // --- High-level state machine for ramping and direction changes ---
-  if (in_direction_change_delay) {
-    if (current_millis - direction_change_start_ms >= 1000) {
-      in_direction_change_delay = false;
-      ramping_up = true;
-      forward = !forward;
-    }
-    return;
-  }
+  // --- High-level state machine for the test pattern ---
+  unsigned long time_in_state = current_millis - state_start_ms;
 
-  if (current_millis - last_ramp_update_ms >= ramp_step_delay_ms) {
-    last_ramp_update_ms = current_millis;
+  switch (current_state) {
+    case RAMP_UP:
+      if (current_millis - last_ramp_update_ms >= ramp_step_delay_ms) {
+        last_ramp_update_ms = current_millis;
+        if (target_speed < max_speed) {
+          target_speed++;
+        } else {
+          current_state = COAST_HIGH;
+          state_start_ms = current_millis;
+        }
+      }
+      break;
 
-    if (ramping_up) {
-      if (target_speed < half_speed) {
-        target_speed++;
-      } else {
-        ramping_up = false;
+    case COAST_HIGH:
+      if (time_in_state >= 3000) {
+        current_state = RAMP_DOWN;
+        state_start_ms = current_millis;
       }
-    } else {
-      if (target_speed > 0) {
-        target_speed--;
-      } else {
-        in_direction_change_delay = true;
-        direction_change_start_ms = current_millis;
+      break;
+
+    case RAMP_DOWN:
+      if (current_millis - last_ramp_update_ms >= ramp_step_delay_ms) {
+        last_ramp_update_ms = current_millis;
+        if (target_speed > max_speed * 0.1) {
+          target_speed--;
+        } else {
+          current_state = COAST_LOW;
+          state_start_ms = current_millis;
+        }
       }
-    }
+      break;
+
+    case COAST_LOW:
+      if (time_in_state >= 3000) {
+        current_state = STOP;
+        state_start_ms = current_millis;
+        target_speed = 0; // Ensure motor is stopped
+      }
+      break;
+
+    case STOP:
+      if (time_in_state >= 2000) {
+        forward = !forward; // Change direction
+        current_state = RAMP_UP;
+        state_start_ms = current_millis;
+      }
+      break;
   }
 
   // --- Low-level non-blocking software PWM and BEMF measurement ---
+  unsigned long time_since_cycle_start = current_micros - last_pwm_cycle_us;
   long on_time_us = map(current_pwm, 0, 255, 0, pwm_period_us);
 
-  if (current_micros - last_pwm_cycle_us >= pwm_period_us) {
+  // Check if it's time to start a new PWM cycle
+  if (time_since_cycle_start >= pwm_period_us) {
     last_pwm_cycle_us = current_micros;
+    time_since_cycle_start = 0; // Reset for the new cycle
     bemf_measured_this_cycle = false;
+  }
 
+  // Determine whether we are in the ON or OFF portion of the PWM pulse
+  if (time_since_cycle_start < on_time_us) {
+    // --- ON Portion: Drive the motor ---
     pinMode(pwmAPin, OUTPUT);
     pinMode(pwmBPin, OUTPUT);
-
     if (forward) {
       digitalWrite(pwmAPin, HIGH);
       digitalWrite(pwmBPin, LOW);
@@ -152,9 +186,11 @@ void loop() {
       digitalWrite(pwmAPin, LOW);
       digitalWrite(pwmBPin, HIGH);
     }
-  }
-
-  if (!bemf_measured_this_cycle && (current_micros - last_pwm_cycle_us > on_time_us)) {
-    update_motor_pwm();
+  } else {
+    // --- OFF Portion: Coast and measure BEMF ---
+    if (!bemf_measured_this_cycle) {
+      update_motor_pwm(); // This function sets pins to INPUT and measures
+      bemf_measured_this_cycle = true;
+    }
   }
 }


### PR DESCRIPTION
This commit replaces the simple ramp-up/ramp-down logic with a more sophisticated finite state machine that implements a detailed motor test pattern.

The new pattern is as follows:
- Ramp up to 100% speed
- Coast at 100% speed for 3 seconds
- Ramp down to 10% speed
- Coast at 10% speed for 3 seconds
- Stop for 2 seconds
- Reverse direction and repeat the cycle

The status LED has also been updated to reflect the new states.