### PR TITLE
feat: Implement dynamic RGB LED status indicator

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -2,3 +2,5 @@
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = seeed_xiao_rp2040
 framework = arduino
+lib_deps =
+    adafruit/Adafruit NeoPixel


### PR DESCRIPTION
Replaces the single-color status LED with the onboard RGB NeoPixel to provide more detailed feedback on the motor's state.

The LED color now dynamically reflects the P-controller's real-time action:
- Green: Accelerating
- Red: Decelerating
- Yellow: Steady speed (coasting)
- Blue: Stopped
- Pink: Changing direction

The blink pattern (solid, slow, fast) is preserved and determined by the high-level state machine. This change required adding the `Adafruit NeoPixel` library and refactoring the status light logic.