### PR TITLE
feat(docs): add plantuml diagram for control loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,7 @@ The control loop operates as follows:
 
 ### Control Loop Diagram
 
-```
-            +------------------+     +------------------+     +------------------+
-Set-point   |                  |     |                  |     |                  |
-(Target --->|    Controller    |---->|      Motor       |---->|      Motor       |----> Actual
- Speed)     | (P-Controller)   | PWM |      Driver      | PWM |                  |      Speed
-            |                  |     |    (BDR-6133)    |     |                  |
-            +------------------+     +------------------+     +------------------+
-                  ^                                                   |
-                  |                                                   |
-                  | Error                                             | BEMF
-                  |                                                   |
-                  +---------------------------------------------------+
-                                        Feedback
-```
+![Control Loop Diagram](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/chatelao/xDuinoRails_RP2040-BDR6133-Tester/main/docs/control_loop.puml)
 
 ### Concept Idea: Soft-Start Routine
 

--- a/docs/control_loop.puml
+++ b/docs/control_loop.puml
@@ -1,0 +1,34 @@
+@startuml
+skinparam componentStyle uml2
+skinparam monochrome true
+skinparam shadowing false
+skinparam classAttributeIconSize 0
+
+
+title Motor Control Loop
+
+frame "Firmware" {
+    [Target Speed] as setpoint
+    [PI Controller] as pi
+    [PWM Generation] as pwm
+}
+
+frame "Hardware" {
+    [Motor Driver] as driver
+    [DC Motor] as motor
+    [Analog-to-Digital\nConverter] as adc
+}
+
+frame "Signal Processing" {
+    [IIR Filter] as filter
+}
+
+setpoint -> pi : speed_setpoint_pps
+pi -> pwm : pwm_duty_cycle
+pwm -> driver
+driver -> motor
+motor -> adc : back_EMF_voltage
+adc -> filter : raw_bemf_adc
+filter -> pi : filtered_speed_pps
+
+@enduml


### PR DESCRIPTION
Adds a PlantUML diagram to the README.md to visualize the motor control loop.

The diagram is generated from a source file `docs/control_loop.puml` and rendered in the README using a web service, so no build step is required.

This replaces the previous ASCII art diagram.