### PR TITLE
Refactor low-level motor control into HAL

### DIFF
--- a/include/motor_control_hal.h
+++ b/include/motor_control_hal.h
@@ -1,0 +1,55 @@
+/**
+ * @file motor_control_hal.h
+ * @brief Hardware Abstraction Layer (HAL) for low-level motor control.
+ *
+ * This file defines a platform-agnostic interface for hardware-accelerated
+ * PWM motor control and BEMF (Back-EMF) measurement. The implementation for
+ * a specific microcontroller must be provided separately.
+ */
+#ifndef MOTOR_CONTROL_HAL_H
+#define MOTOR_CONTROL_HAL_H
+
+#include <cstdint>
+
+/**
+ * @brief Callback function pointer type for BEMF updates.
+ *
+ * This function is called from an interrupt context whenever a new
+ * differential BEMF measurement is available from the hardware. It is the
+ * responsibility of the callee to perform any necessary filtering, processing,
+ * and control logic adjustments.
+ *
+ * @param raw_bemf_value The raw, unfiltered differential BEMF value, calculated
+ *                       as the absolute difference between the two ADC readings.
+ */
+typedef void (*hal_bemf_update_callback_t)(int raw_bemf_value);
+
+/**
+ * @brief Initializes the low-level hardware for motor control.
+ *
+ * This function configures the hardware timers, PWM peripherals, ADC, and DMA
+ * for hardware-accelerated motor control and BEMF measurement. It must be
+ * called once during the application's setup phase.
+ *
+ * @param pwm_a_pin The GPIO pin number for PWM channel A (e.g., forward).
+ * @param pwm_b_pin The GPIO pin number for PWM channel B (e.g., reverse).
+ * @param bemf_a_pin The GPIO pin number for ADC input connected to motor terminal A.
+ * @param bemf_b_pin The GPIO pin number for ADC input connected to motor terminal B.
+ * @param callback A pointer to a function that will be called from an interrupt
+ *                 context with new BEMF data.
+ */
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback);
+
+/**
+ * @brief Sets the motor's PWM duty cycle and direction.
+ *
+ * This function updates the PWM hardware with the new duty cycle. It should
+ * be called periodically from the main application loop to reflect the latest
+ * output from the motor control algorithm (e.g., a PI controller).
+ *
+ * @param duty_cycle The desired duty cycle, typically in a range from 0 to 255.
+ * @param forward The desired motor direction (true for forward, false for reverse).
+ */
+void hal_motor_set_pwm(int duty_cycle, bool forward);
+
+#endif // MOTOR_CONTROL_HAL_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,24 +76,7 @@ SimpleKalmanFilter bemfKalmanFilter(BEMF_MEA_E, BEMF_EST_E, BEMF_Q);
 const int pwm_frequency = 1000; ///< PWM frequency in Hz.
 const long pwm_period_us = 1000000 / pwm_frequency; ///< PWM period in microseconds.
 #else // USE_RP2040_LOWLEVEL
-#include "hardware/pwm.h"
-#include "hardware/dma.h"
-#include "hardware/adc.h"
-#include "hardware/irq.h"
-
-//== Hardware PWM & BEMF Measurement Parameters ==
-const uint PWM_FREQUENCY_HZ = 25000;
-const uint16_t PWM_WRAP_VALUE = (125000000 / PWM_FREQUENCY_HZ) - 1;
-const uint BEMF_MEASUREMENT_DELAY_US = 10;
-
-// Ring buffer for DMA.
-const uint BEMF_RING_BUFFER_SIZE = 64;
-
-//== Globals for Hardware Control ==
-uint dma_channel;
-uint motor_pwm_slice;
-volatile uint16_t bemf_ring_buffer[BEMF_RING_BUFFER_SIZE];
-
+#include "motor_control_hal.h"
 #endif
 
 //== State Machine for Test Pattern ==
@@ -125,24 +108,17 @@ volatile bool motor_forward = true;  ///< Current direction of the motor. true f
 #ifndef USE_RP2040_LOWLEVEL
 struct repeating_timer pwm_timer; ///< Holds the repeating timer instance for the PWM cycle.
 #else
-// Forward Declarations
-void dma_irq_handler();
-void setup_hardware_control();
-void update_pwm_duty_cycle();
-void on_pwm_wrap();
-int64_t delayed_adc_trigger_callback(alarm_id_t id, void *user_data);
-
-
-void dma_irq_handler() {
-    dma_hw->ints0 = 1u << dma_channel;
-
-    uint32_t sum_A = 0, sum_B = 0;
-    for (uint i = 0; i < BEMF_RING_BUFFER_SIZE; i += 2) {
-        sum_B += bemf_ring_buffer[i]; // ADC2
-        sum_A += bemf_ring_buffer[i + 1]; // ADC3
-    }
-    int measured_bemf = abs((int)(sum_A / (BEMF_RING_BUFFER_SIZE / 2)) - (int)(sum_B / (BEMF_RING_BUFFER_SIZE / 2)));
-
+/**
+ * @brief Callback function for the HAL to provide new BEMF data.
+ *
+ * This function is called from an interrupt context by the hardware abstraction
+ * layer whenever a new raw BEMF measurement is available. It performs the
+ * two-stage filtering (EMA and Kalman) and runs the PI controller logic.
+ *
+ * @param measured_bemf The raw, unfiltered differential BEMF value.
+ */
+void on_bemf_update(int measured_bemf) {
+    // Apply EMA filter to smooth the raw BEMF reading
     static float smoothed_bemf = 0.0;
     static bool filter_initialized = false;
     if (!filter_initialized) {
@@ -151,96 +127,34 @@ void dma_irq_handler() {
     } else {
         smoothed_bemf = (EMA_ALPHA * measured_bemf) + ((1.0 - EMA_ALPHA) * smoothed_bemf);
     }
+
+    // Apply Kalman filter for additional smoothing
     float kalman_filtered_bemf = bemfKalmanFilter.updateEstimate(smoothed_bemf);
 
+    // Detect rising edge of a commutation pulse
     bool current_bemf_state = (kalman_filtered_bemf > bemf_threshold);
     if (current_bemf_state && !last_bemf_state) {
         commutation_pulse_count++;
     }
     last_bemf_state = current_bemf_state;
 
+    // Run the PI-controller if it's enabled
     if (pi_controller_enabled) {
         bool is_in_rangiermodus = (target_speed > 0 && target_speed <= rangiermodus_speed_threshold);
-        if (is_in_rangiermodus != was_in_rangiermodus) pi_controller.reset();
+        if (is_in_rangiermodus != was_in_rangiermodus) {
+            pi_controller.reset();
+        }
         was_in_rangiermodus = is_in_rangiermodus;
+
         pi_controller.setGains(is_in_rangiermodus ? Kp_rangier : Kp_normal, is_in_rangiermodus ? Ki_rangier : Ki_normal);
 
         int measured_speed = map(measured_speed_pps, 0, 500, 0, 255);
         current_pwm = pi_controller.calculate(target_speed, measured_speed, current_pwm);
     }
-
-    dma_channel_set_write_addr(dma_channel, bemf_ring_buffer, true);
-}
-
-void update_pwm_duty_cycle() {
-    uint16_t level = map(current_pwm, 0, 255, 0, PWM_WRAP_VALUE);
-    if (motor_forward) {
-        pwm_set_gpio_level(pwmAPin, level);
-        pwm_set_gpio_level(pwmBPin, 0);
-    } else {
-        pwm_set_gpio_level(pwmAPin, 0);
-        pwm_set_gpio_level(pwmBPin, level);
-    }
-}
-
-int64_t delayed_adc_trigger_callback(alarm_id_t id, void *user_data) {
-    adc_run(true);
-    return 0; // Do not reschedule
-}
-
-void on_pwm_wrap() {
-    pwm_clear_irq(motor_pwm_slice);
-    add_alarm_in_us(BEMF_MEASUREMENT_DELAY_US, delayed_adc_trigger_callback, NULL, true);
-}
-
-
-void setup_hardware_control() {
-    // --- ADC and DMA Setup ---
-    adc_init();
-    adc_gpio_init(bemfBPin);
-    adc_gpio_init(bemfAPin);
-    adc_set_round_robin((1u << 2) | (1u << 3));
-    adc_select_input(2);
-    adc_fifo_setup(true, true, 1, false, false); // DREQ on every sample
-
-    dma_channel = dma_claim_unused_channel(true);
-    dma_channel_config dma_config = dma_channel_get_default_config(dma_channel);
-    // Transfer 16-bit ADC samples
-    channel_config_set_transfer_data_size(&dma_config, DMA_SIZE_16);
-    // Always read from the same ADC FIFO address
-    channel_config_set_read_increment(&dma_config, false);
-    // Increment the write address to fill the buffer
-    channel_config_set_write_increment(&dma_config, true);
-    // DMA is paced by the ADC's DREQ signal
-    channel_config_set_dreq(&dma_config, DREQ_ADC);
-    // Wrap the write address back to the start when the buffer is full (64 bytes = 2^6)
-    channel_config_set_ring(&dma_config, true, 6);
-
-    dma_channel_configure(dma_channel, &dma_config, bemf_ring_buffer, &adc_hw->fifo, BEMF_RING_BUFFER_SIZE, false);
-    dma_channel_set_irq0_enabled(dma_channel, true);
-    irq_set_exclusive_handler(DMA_IRQ_0, dma_irq_handler);
-    irq_set_enabled(DMA_IRQ_0, true);
-
-    // --- PWM Setup for Motor Control ---
-    gpio_set_function(pwmAPin, GPIO_FUNC_PWM);
-    gpio_set_function(pwmBPin, GPIO_FUNC_PWM);
-    motor_pwm_slice = pwm_gpio_to_slice_num(pwmAPin);
-
-    pwm_config motor_pwm_conf = pwm_get_default_config();
-    pwm_config_set_wrap(&motor_pwm_conf, PWM_WRAP_VALUE);
-    pwm_init(motor_pwm_slice, &motor_pwm_conf, true);
-
-    // --- PWM Interrupt for Synchronization ---
-    pwm_clear_irq(motor_pwm_slice);
-    pwm_set_irq_enabled(motor_pwm_slice, true);
-    irq_set_exclusive_handler(PWM_IRQ_WRAP, on_pwm_wrap);
-    irq_set_enabled(PWM_IRQ_WRAP, true);
-
-    // Start DMA, which will wait for the first ADC trigger.
-    dma_channel_set_write_addr(dma_channel, bemf_ring_buffer, true);
 }
 #endif
 
+#ifndef USE_RP2040_LOWLEVEL
 /**
  * @brief Timer callback for the PWM OFF phase.
  *
@@ -251,7 +165,6 @@ void setup_hardware_control() {
  * @param alarm_id The ID of the alarm that triggered.
  * @return 0
  */
-#ifndef USE_RP2040_LOWLEVEL
 int64_t pwm_off_callback(alarm_id_t alarm_id, void *user_data) {
   // 1. Put H-Bridge into high-impedance state to measure BEMF
   pinMode(pwmAPin, INPUT);
@@ -377,7 +290,7 @@ void setup() {
 #ifndef USE_RP2040_LOWLEVEL
   add_repeating_timer_us(pwm_period_us, pwm_on_callback, NULL, &pwm_timer);
 #else
-  setup_hardware_control();
+  hal_motor_init(pwmAPin, pwmBPin, bemfAPin, bemfBPin, on_bemf_update);
 #endif
 }
 
@@ -595,6 +508,6 @@ void loop() {
   // high-level state machine and speed calculations. The CPU load is
   // significantly reduced.
 #ifdef USE_RP2040_LOWLEVEL
-  update_pwm_duty_cycle();
+  hal_motor_set_pwm(current_pwm, motor_forward);
 #endif
 }

--- a/src/motor_control_hal_rp2040.cpp
+++ b/src/motor_control_hal_rp2040.cpp
@@ -1,0 +1,150 @@
+/**
+ * @file motor_control_hal_rp2040.cpp
+ * @brief RP2040-specific implementation for the motor control HAL.
+ *
+ * This file provides the concrete implementation of the functions defined in
+ * motor_control_hal.h for the Raspberry Pi RP2040 microcontroller. It uses
+ * the Pico-SDK's hardware peripherals (PWM, ADC, DMA) for efficient,
+ * non-blocking motor control and BEMF measurement.
+ */
+
+#include "motor_control_hal.h"
+
+#if defined(USE_RP2040_LOWLEVEL)
+
+#include <Arduino.h>
+#include "hardware/pwm.h"
+#include "hardware/dma.h"
+#include "hardware/adc.h"
+#include "hardware/irq.h"
+
+//== Hardware PWM & BEMF Measurement Parameters ==
+const uint PWM_FREQUENCY_HZ = 25000;
+static uint16_t PWM_WRAP_VALUE = (125000000 / PWM_FREQUENCY_HZ) - 1;
+const uint BEMF_MEASUREMENT_DELAY_US = 10;
+const uint BEMF_RING_BUFFER_SIZE = 64;
+
+//== Static Globals for Hardware Control ==
+static uint dma_channel;
+static uint motor_pwm_slice;
+static volatile uint16_t bemf_ring_buffer[BEMF_RING_BUFFER_SIZE];
+static hal_bemf_update_callback_t bemf_callback = nullptr;
+
+// Pin definitions, to be set in hal_motor_init
+static uint8_t g_pwm_a_pin;
+static uint8_t g_pwm_b_pin;
+
+// Forward Declarations
+static void dma_irq_handler();
+static int64_t delayed_adc_trigger_callback(alarm_id_t id, void *user_data);
+static void on_pwm_wrap();
+
+/**
+ * @brief DMA interrupt handler.
+ *
+ * This ISR is triggered when the DMA transfer of ADC samples to the ring
+ * buffer is complete. It calculates the average differential BEMF, invokes
+ * the registered callback, and then restarts the DMA transfer.
+ */
+static void dma_irq_handler() {
+    dma_hw->ints0 = 1u << dma_channel;
+
+    uint32_t sum_A = 0, sum_B = 0;
+    // The ADC round-robin is configured for B(ADC2) then A(ADC3).
+    for (uint i = 0; i < BEMF_RING_BUFFER_SIZE; i += 2) {
+        sum_B += bemf_ring_buffer[i];
+        sum_A += bemf_ring_buffer[i + 1];
+    }
+    int measured_bemf = abs((int)(sum_A / (BEMF_RING_BUFFER_SIZE / 2)) - (int)(sum_B / (BEMF_RING_BUFFER_SIZE / 2)));
+
+    // Invoke the callback with the raw BEMF data
+    if (bemf_callback) {
+        bemf_callback(measured_bemf);
+    }
+
+    // Restart DMA transfer for the next cycle
+    dma_channel_set_write_addr(dma_channel, bemf_ring_buffer, true);
+}
+
+/**
+ * @brief One-shot timer callback to trigger ADC conversion.
+ *
+ * This is called by an alarm a short time after the PWM wrap to ensure
+ * the motor windings are in a high-impedance state. It starts the ADC,
+ * which will then use DMA to fill the buffer.
+ */
+static int64_t delayed_adc_trigger_callback(alarm_id_t id, void *user_data) {
+    adc_run(true);
+    return 0; // Do not reschedule
+}
+
+/**
+ * @brief PWM wrap interrupt handler.
+ *
+ * This ISR is triggered at the end of each PWM cycle. It sets a one-shot
+ * hardware timer to trigger the ADC measurement after a short delay.
+ */
+static void on_pwm_wrap() {
+    pwm_clear_irq(motor_pwm_slice);
+    add_alarm_in_us(BEMF_MEASUREMENT_DELAY_US, delayed_adc_trigger_callback, NULL, true);
+}
+
+//== Public HAL Function Implementations ==
+
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback) {
+    g_pwm_a_pin = pwm_a_pin;
+    g_pwm_b_pin = pwm_b_pin;
+    bemf_callback = callback;
+
+    // --- ADC and DMA Setup ---
+    adc_init();
+    adc_gpio_init(bemf_b_pin);
+    adc_gpio_init(bemf_a_pin);
+    adc_set_round_robin((1u << (bemf_b_pin - 26)) | (1u << (bemf_a_pin - 26))); // Assumes pins are A0-A3 -> ADC0-3
+    adc_select_input(bemf_b_pin - 26);
+    adc_fifo_setup(true, true, 1, false, false); // DREQ on every sample
+
+    dma_channel = dma_claim_unused_channel(true);
+    dma_channel_config dma_config = dma_channel_get_default_config(dma_channel);
+    channel_config_set_transfer_data_size(&dma_config, DMA_SIZE_16);
+    channel_config_set_read_increment(&dma_config, false);
+    channel_config_set_write_increment(&dma_config, true);
+    channel_config_set_dreq(&dma_config, DREQ_ADC);
+    channel_config_set_ring(&dma_config, true, 6); // Ring buffer size 64 = 2^6
+
+    dma_channel_configure(dma_channel, &dma_config, bemf_ring_buffer, &adc_hw->fifo, BEMF_RING_BUFFER_SIZE, false);
+    dma_channel_set_irq0_enabled(dma_channel, true);
+    irq_set_exclusive_handler(DMA_IRQ_0, dma_irq_handler);
+    irq_set_enabled(DMA_IRQ_0, true);
+
+    // --- PWM Setup for Motor Control ---
+    gpio_set_function(g_pwm_a_pin, GPIO_FUNC_PWM);
+    gpio_set_function(g_pwm_b_pin, GPIO_FUNC_PWM);
+    motor_pwm_slice = pwm_gpio_to_slice_num(g_pwm_a_pin);
+
+    pwm_config motor_pwm_conf = pwm_get_default_config();
+    pwm_config_set_wrap(&motor_pwm_conf, PWM_WRAP_VALUE);
+    pwm_init(motor_pwm_slice, &motor_pwm_conf, true);
+
+    // --- PWM Interrupt for Synchronization ---
+    pwm_clear_irq(motor_pwm_slice);
+    pwm_set_irq_enabled(motor_pwm_slice, true);
+    irq_set_exclusive_handler(PWM_IRQ_WRAP, on_pwm_wrap);
+    irq_set_enabled(PWM_IRQ_WRAP, true);
+
+    // Start DMA, which will wait for the first ADC trigger.
+    dma_channel_set_write_addr(dma_channel, bemf_ring_buffer, true);
+}
+
+void hal_motor_set_pwm(int duty_cycle, bool forward) {
+    uint16_t level = map(duty_cycle, 0, 255, 0, PWM_WRAP_VALUE);
+    if (forward) {
+        pwm_set_gpio_level(g_pwm_a_pin, level);
+        pwm_set_gpio_level(g_pwm_b_pin, 0);
+    } else {
+        pwm_set_gpio_level(g_pwm_a_pin, 0);
+        pwm_set_gpio_level(g_pwm_b_pin, level);
+    }
+}
+
+#endif // USE_RP2040_LOWLEVEL && ARDUINO_RASPBERRY_PI_PICO


### PR DESCRIPTION
This commit refactors the hardware-specific motor control logic for the RP2040 into a Hardware Abstraction Layer (HAL).

The low-level PWM, ADC, and DMA setup and interrupt handling have been moved from 'main.cpp' into a new pair of files:
- 'include/motor_control_hal.h': Defines the abstract interface for the HAL.
- 'src/motor_control_hal_rp2040.cpp': Provides the concrete implementation for the RP2040.

'main.cpp' has been updated to use this new HAL, making the main application logic more portable and easier to maintain. A callback mechanism is used to pass BEMF data from the HAL's interrupt service routine back to the main application for filtering and PI control.