### PR TITLE
feat(docs): add comparison page for H0 motors

### DIFF
--- a/docs/Motoren.md
+++ b/docs/Motoren.md
@@ -1,0 +1,23 @@
+# Vergleich gängiger H0-Modelleisenbahnmotoren
+
+Dieses Dokument bietet einen Überblick über die typischen statischen und dynamischen, elektrischen und mechanischen Eigenschaften verschiedener gängiger Motortypen, die in H0-Modelleisenbahnen zu finden sind. Die Werte für ältere Motortypen sind als Richtwerte aus der Praxis zu verstehen, da offizielle Datenblätter oft nicht verfügbar sind.
+
+| Eigenschaft                  | Märklin 3-Pol (LFCM/SFCM)¹         | Märklin 3-Pol (DCM)²                | Märklin 5-Pol HLA³                  | Glockenanker (z.B. Faulhaber)⁴        |
+| ------------------------------ | ---------------------------------- | ----------------------------------- | ----------------------------------- | ------------------------------------- |
+| **Technologie**                | 3-Pol Trommel-/Scheibenkollektor   | 3-Pol Trommelkollektor              | 5-Pol Trommelkollektor (DC)         | Eisenloser Rotor (Coreless DC)        |
+| **Nennspannung**               | 10-16 V (~)                        | 10-16 V (~)                         | 12-18 V (DC)                        | 12 V (DC)                             |
+| **Leerlaufstromaufnahme**      | ca. 100-200 mA                     | ca. 80-150 mA                       | ca. 50-100 mA                       | < 20 mA                               |
+| **Blockierstromaufnahme**      | > 1000 mA                          | ca. 800-1200 mA                     | ca. 600-1000 mA                     | ca. 300-500 mA                        |
+| **Leerlaufdrehzahl (bei 12V)** | Hoch, > 15.000 U/min               | Hoch, > 15.000 U/min                | ca. 12.000-15.000 U/min             | ca. 8.000-12.000 U/min                |
+| **Wirkungsgrad (ca.)**         | Niedrig (~ 40-50%)                 | Moderat (~ 50-60%)                  | Hoch (~ 70-80%)                     | Sehr hoch (> 80%)                     |
+| **Rastmoment (Cogging)**       | Sehr stark spürbar                 | Stark spürbar                       | Gering spürbar                      | Nicht vorhanden                       |
+| **Anlaufspannung**             | Hoch                               | Moderat bis hoch                    | Niedrig                             | Sehr niedrig                          |
+| **Vorteile**                   | Robust, einfach, hohe Endgeschw.   | Robust, zuverlässig                | Gute Regelbarkeit, hohes Drehmoment | Exzellente Regelbarkeit, leise, effizient |
+| **Nachteile**                  | Hoher Stromverbrauch, schlechte Langsamfahreigenschaften, laut | Mäßige Langsamfahreigenschaften     | Teurer als 3-Pol-Motoren            | Empfindlich, teuer                    |
+
+---
+**Anmerkungen:**
+¹ **LFCM/SFCM:** (Großer/Kleiner) Flach-/Scheibenkollektor-Feldspulen-Motor. Die klassischen Allstrommotoren von Märklin.
+² **DCM:** Trommelkollektor-Motor. Eine Weiterentwicklung mit verbesserter Leistung gegenüber dem SFCM/LFCM.
+³ **HLA:** Hochleistungsantrieb. Ein Umbausatz von Märklin, der einen 5-poligen Gleichstrommotor mit Permanentmagnet enthält.
+⁴ **Glockenanker-Motor:** Allgemeine Bezeichnung für eisenlose Motoren (z.B. Faulhaber, Maxon), die oft für anspruchsvolle Umbauten verwendet werden.


### PR DESCRIPTION
Creates a new Markdown page at `docs/Motoren.md` that provides a tabular overview of common H0 model railway motors.

The table compares the electrical, mechanical, and dynamic characteristics of Märklin 3-pole, 5-pole, and coreless (Glockenanker) motors to serve as a reference for model railroaders.