### PR TITLE
feat(ci): Build on push and release, upload firmware on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,11 @@ jobs:
           pip install --upgrade platformio
           pip install -r scripts/requirements.txt
 
-      - name: Build project
-        run: pio run
+      - name: Build Firmware
+        run: pio run --environment seeed_xiao_rp2040
+
+      - name: Rename Firmware
+        run: mv .pio/build/seeed_xiao_rp2040/firmware.uf2 xDuinoRails_Firmware.uf2
 
       - name: Run simulation test
         run: pio test --environment native
@@ -42,5 +45,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            .pio/build/seeed_xiao_rp2040/firmware.uf2
+            xDuinoRails_Firmware.uf2
             simulation_graph.png


### PR DESCRIPTION
This commit updates the GitHub workflow to meet the following requirements:
- The firmware is now built on every push to any branch to ensure continuous integration.
- The workflow also runs when a release is published.
- The built firmware (`.uf2` file) and the simulation graph are only uploaded as release assets during the `release` event.

This provides faster feedback during development while ensuring that releases are always populated with the correct build artifacts.