### PR TITLE
feat(test): Add native tests for motor driver

### DIFF
--- a/lib/XDuinoRails/src/SimpleKalmanFilterWrapper.cpp
+++ b/lib/XDuinoRails/src/SimpleKalmanFilterWrapper.cpp
@@ -1,0 +1,10 @@
+#if ARDUINO
+#include "SimpleKalmanFilterWrapper.h"
+
+SimpleKalmanFilterWrapper::SimpleKalmanFilterWrapper(float mea_e, float est_e, float q)
+    : _filter(mea_e, est_e, q) {}
+
+float SimpleKalmanFilterWrapper::updateEstimate(float measurement) {
+    return _filter.updateEstimate(measurement);
+}
+#endif // ARDUINO

--- a/lib/XDuinoRails/src/SimpleKalmanFilterWrapper.h
+++ b/lib/XDuinoRails/src/SimpleKalmanFilterWrapper.h
@@ -1,0 +1,18 @@
+#if ARDUINO
+#ifndef SIMPLE_KALMAN_FILTER_WRAPPER_H
+#define SIMPLE_KALMAN_FILTER_WRAPPER_H
+
+#include "interfaces/IKalmanFilter.h"
+#include <SimpleKalmanFilter.h>
+
+class SimpleKalmanFilterWrapper : public IKalmanFilter {
+public:
+    SimpleKalmanFilterWrapper(float mea_e, float est_e, float q);
+    float updateEstimate(float measurement) override;
+
+private:
+    SimpleKalmanFilter _filter;
+};
+
+#endif // SIMPLE_KALMAN_FILTER_WRAPPER_H
+#endif // ARDUINO

--- a/lib/XDuinoRails/src/XDuinoRails_MotorDriver.h
+++ b/lib/XDuinoRails/src/XDuinoRails_MotorDriver.h
@@ -7,12 +7,20 @@
 
 #include "pi_controller.h"
 
+#if defined(TESTING)
+unsigned long millis();
+#endif
+
 // Forward declaration of the implementation class
 class XDuinoRails_MotorDriver_Impl;
+class IKalmanFilter;
 
 class XDuinoRails_MotorDriver {
 public:
     XDuinoRails_MotorDriver(int pwmAPin, int pwmBPin, int bemfAPin, int bemfBPin);
+#if defined(TESTING)
+    XDuinoRails_MotorDriver(int pwmAPin, int pwmBPin, int bemfAPin, int bemfBPin, IKalmanFilter* filter);
+#endif
     ~XDuinoRails_MotorDriver();
 
     void begin();
@@ -21,6 +29,7 @@ public:
     void setTargetSpeed(int speed);
     int getTargetSpeed() const;
     float getMeasuredSpeedPPS() const;
+    float getCurrentSpeedSetpoint() const;
 
     void setDirection(bool forward);
     bool getDirection() const;
@@ -30,6 +39,7 @@ public:
 
     void setPIgains(float kp, float ki);
     void setFilterParameters(float ema_alpha, float mea_e, float est_e, float q);
+    void setStallDetection(bool enabled);
 
     void setAcceleration(float rate);
     void setDeceleration(float rate);

--- a/lib/XDuinoRails/src/interfaces/IKalmanFilter.h
+++ b/lib/XDuinoRails/src/interfaces/IKalmanFilter.h
@@ -1,0 +1,10 @@
+#ifndef IKALMAN_FILTER_H
+#define IKALMAN_FILTER_H
+
+class IKalmanFilter {
+public:
+    virtual ~IKalmanFilter() {}
+    virtual float updateEstimate(float measurement) = 0;
+};
+
+#endif // IKALMAN_FILTER_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,11 @@
 [platformio]
-default_envs = seeed_xiao_rp2040
+default_envs = native_test
+test_dir = test
+
+[env:native_test]
+platform = native
+build_flags = -DTESTING
+lib_ignore = SimpleKalmanFilter
 
 [env:seeed_xiao_rp2040]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git

--- a/test/test_native/MockKalmanFilter.h
+++ b/test/test_native/MockKalmanFilter.h
@@ -1,0 +1,15 @@
+#ifndef MOCK_KALMAN_FILTER_H
+#define MOCK_KALMAN_FILTER_H
+
+#include "interfaces/IKalmanFilter.h"
+
+class MockKalmanFilter : public IKalmanFilter {
+public:
+    float updateEstimate(float measurement) override {
+        // In the mock, just pass the measurement through directly.
+        // This allows us to test the rest of the system without the filter's influence.
+        return measurement;
+    }
+};
+
+#endif // MOCK_KALMAN_FILTER_H

--- a/test/test_native/test_motor_driver.cpp
+++ b/test/test_native/test_motor_driver.cpp
@@ -1,0 +1,144 @@
+#include "XDuinoRails_MotorDriver.h"
+#include "MockKalmanFilter.h"
+#include <cassert>
+#include <iostream>
+
+// --- Mock HAL & Arduino functions ---
+extern unsigned long mock_millis_count;
+
+void advance_time_ms(unsigned long ms) {
+    mock_millis_count += ms;
+}
+
+// Provide simple stub implementations for the HAL functions to satisfy the linker.
+extern "C" {
+    void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, void (*callback)(int)) {}
+    void hal_motor_set_pwm(int duty_cycle, bool forward) {}
+}
+
+void test_acceleration_deceleration() {
+    std::cout << "--- Running Test: test_acceleration_deceleration ---" << std::endl;
+    mock_millis_count = 0;
+    MockKalmanFilter* mock_filter = new MockKalmanFilter();
+    XDuinoRails_MotorDriver driver(0, 1, 2, 3, mock_filter);
+    driver.begin();
+
+    // Disable stall detection for this test
+    driver.setStallDetection(false);
+
+    // --- Test Acceleration ---
+    std::cout << "  Testing Acceleration..." << std::endl;
+    driver.setAcceleration(50); // 50 speed units per second
+    driver.setDeceleration(0);
+    driver.setTargetSpeed(100);
+
+    // Simulate updates.
+    for (int i = 0; i < 100; ++i) {
+        advance_time_ms(10);
+        driver.update();
+    }
+    float current_setpoint = driver.getCurrentSpeedSetpoint();
+    std::cout << "  Speed setpoint after 1s: " << current_setpoint << std::endl;
+    assert(current_setpoint > 48 && current_setpoint < 52);
+
+    // Simulate another second
+    for (int i = 0; i < 100; ++i) {
+        advance_time_ms(10);
+        driver.update();
+    }
+    current_setpoint = driver.getCurrentSpeedSetpoint();
+    std::cout << "  Speed setpoint after 2s: " << current_setpoint << std::endl;
+    assert(current_setpoint == 100);
+
+
+    // --- Test Deceleration ---
+    std::cout << "  Testing Deceleration..." << std::endl;
+    driver.setAcceleration(0);
+    driver.setDeceleration(100); // 100 speed units per second
+    driver.setTargetSpeed(0);
+
+    // Simulate 0.5 seconds of updates
+    for (int i = 0; i < 50; ++i) {
+        advance_time_ms(10);
+        driver.update();
+    }
+    current_setpoint = driver.getCurrentSpeedSetpoint();
+    std::cout << "  Speed setpoint after 0.5s deceleration: " << current_setpoint << std::endl;
+    assert(current_setpoint > 48 && current_setpoint < 52);
+
+
+    // Simulate another 0.5 seconds
+    for (int i = 0; i < 50; ++i) {
+        advance_time_ms(10);
+        driver.update();
+    }
+    current_setpoint = driver.getCurrentSpeedSetpoint();
+    std::cout << "  Speed setpoint after 1s deceleration: " << current_setpoint << std::endl;
+    assert(current_setpoint == 0);
+
+    std::cout << "--- Test Passed: test_acceleration_deceleration ---" << std::endl;
+}
+
+void test_stall_detection() {
+    std::cout << "--- Running Test: test_stall_detection ---" << std::endl;
+    mock_millis_count = 0;
+    MockKalmanFilter* mock_filter = new MockKalmanFilter();
+    XDuinoRails_MotorDriver driver(0, 1, 2, 3, mock_filter);
+    driver.begin();
+
+    driver.setTargetSpeed(100);
+    driver.update(); // Set the initial target speed
+
+    // Simulate 1.5 seconds of a stalled motor (measured speed is 0)
+    for (int i = 0; i < 150; ++i) {
+        advance_time_ms(10);
+        driver.update();
+    }
+
+    int final_speed = driver.getTargetSpeed();
+    std::cout << "  Target speed after 1.5s stalled: " << final_speed << std::endl;
+    assert(final_speed == 0);
+    std::cout << "--- Test Passed: test_stall_detection ---" << std::endl;
+}
+
+void test_startup_kick() {
+    std::cout << "--- Running Test: test_startup_kick ---" << std::endl;
+    mock_millis_count = 0; // Reset time for this test
+
+    MockKalmanFilter* mock_filter = new MockKalmanFilter();
+    XDuinoRails_MotorDriver driver(0, 1, 2, 3, mock_filter);
+    driver.begin();
+
+    driver.setStartupKick(150, 100); // 150 PWM for 100ms
+    driver.setTargetSpeed(100); // This should trigger the kick
+
+    advance_time_ms(10);
+    driver.update();
+    int pwm = driver.getCurrentPWM();
+    std::cout << "  PWM immediately after kick start: " << pwm << std::endl;
+    assert(pwm == 150);
+
+    // Simulate 50ms of updates
+    advance_time_ms(50);
+    driver.update();
+    pwm = driver.getCurrentPWM();
+    std::cout << "  PWM after 50ms: " << pwm << std::endl;
+    assert(pwm == 150);
+
+    // Simulate another 60ms (total 110ms, kick should be over)
+    advance_time_ms(60);
+    driver.update();
+    pwm = driver.getCurrentPWM();
+    std::cout << "  PWM after 110ms: " << pwm << std::endl;
+    assert(pwm != 150);
+
+    std::cout << "--- Test Passed: test_startup_kick ---" << std::endl;
+}
+
+
+int main() {
+    test_acceleration_deceleration();
+    test_stall_detection();
+    test_startup_kick();
+    return 0;
+}


### PR DESCRIPTION
This commit introduces a native test suite for the `XDuinoRails_MotorDriver` class, significantly improving test coverage for core features.

Key changes:
- Added a new test file `test/test_native/test_motor_driver.cpp` with tests for:
  - Acceleration and deceleration ramps
  - Stall detection
  - Startup kick
- Refactored the `XDuinoRails_MotorDriver` to allow for native testing by:
  - Introducing an `IKalmanFilter` interface to mock out the Arduino-dependent `SimpleKalmanFilter` library.
  - Adding a `setStallDetection` method to disable the feature during tests that don't require it.
  - Moving the startup kick logic to the main `update` loop to make it testable.
- Added a mock `millis()` function for the native test environment.