### PR TITLE
feat(hal): add ESP32 support with hardware-timed BEMF

### DIFF
--- a/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_esp32.cpp
+++ b/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_esp32.cpp
@@ -1,0 +1,174 @@
+/**
+ * @file motor_control_hal_esp32.cpp
+ * @brief ESP32-specific implementation for the motor control HAL.
+ */
+
+#include "motor_control_hal.h"
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+#include <Arduino.h>
+#include "driver/mcpwm_prelude.h"
+#include "driver/gptimer.h"
+#include "soc/soc_caps.h"
+
+// PWM frequency for the motor driver
+const uint32_t PWM_FREQUENCY_HZ = 25000;
+// Timer resolution for PWM
+const uint32_t PWM_TIMER_RESOLUTION_HZ = 10 * 1000 * 1000; // 10 MHz
+// BEMF measurement cooldown delay
+const uint32_t BEMF_MEASUREMENT_DELAY_US = 10;
+
+// Static Globals for Hardware Control
+static hal_bemf_update_callback_t bemf_callback = nullptr;
+static uint8_t g_pwm_a_pin;
+static uint8_t g_pwm_b_pin;
+static uint8_t g_bemf_a_pin;
+static uint8_t g_bemf_b_pin;
+
+static mcpwm_cmpr_handle_t comparator_a = nullptr;
+static mcpwm_cmpr_handle_t comparator_b = nullptr;
+static mcpwm_oper_handle_t oper = nullptr;
+static mcpwm_timer_handle_t timer = nullptr;
+static gptimer_handle_t gptimer = nullptr;
+
+static bool IRAM_ATTR gptimer_alarm_isr_handler(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_data);
+
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback) {
+    g_pwm_a_pin = pwm_a_pin;
+    g_pwm_b_pin = pwm_b_pin;
+    g_bemf_a_pin = bemf_a_pin;
+    g_bemf_b_pin = bemf_b_pin;
+    bemf_callback = callback;
+
+    // --- MCPWM Setup ---
+    mcpwm_timer_config_t timer_config = {
+        .group_id = 0,
+        .clk_src = MCPWM_TIMER_CLK_SRC_DEFAULT,
+        .resolution_hz = PWM_TIMER_RESOLUTION_HZ,
+        .count_mode = MCPWM_TIMER_COUNT_MODE_UP,
+        .period_ticks = PWM_TIMER_RESOLUTION_HZ / PWM_FREQUENCY_HZ,
+    };
+    mcpwm_new_timer(&timer_config, &timer);
+
+    mcpwm_operator_config_t operator_config = {
+        .group_id = 0,
+    };
+    mcpwm_new_operator(&operator_config, &oper);
+    mcpwm_operator_connect_timer(oper, timer);
+
+    mcpwm_comparator_config_t comparator_config = {
+        .flags.update_cmp_on_tez = true,
+    };
+    mcpwm_new_comparator(oper, &comparator_config, &comparator_a);
+    mcpwm_new_comparator(oper, &comparator_config, &comparator_b);
+
+    mcpwm_generator_handle_t generator_a = nullptr;
+    mcpwm_generator_config_t gen_config_a = { .gen_gpio_num = g_pwm_a_pin };
+    mcpwm_new_generator(oper, &gen_config_a, &generator_a);
+
+    mcpwm_generator_handle_t generator_b = nullptr;
+    mcpwm_generator_config_t gen_config_b = { .gen_gpio_num = g_pwm_b_pin };
+    mcpwm_new_generator(oper, &gen_config_b, &generator_b);
+
+    // Set actions for generators to produce standard PWM
+    mcpwm_generator_set_action_on_timer_event(generator_a, MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY, MCPWM_GEN_ACTION_HIGH));
+    mcpwm_generator_set_action_on_compare_event(generator_a, MCPWM_GEN_COMPARE_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, comparator_a, MCPWM_GEN_ACTION_LOW));
+    mcpwm_generator_set_action_on_timer_event(generator_b, MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY, MCPWM_GEN_ACTION_HIGH));
+    mcpwm_generator_set_action_on_compare_event(generator_b, MCPWM_GEN_COMPARE_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, comparator_b, MCPWM_GEN_ACTION_LOW));
+
+    mcpwm_timer_enable(timer);
+    mcpwm_timer_start_stop(timer, MCPWM_TIMER_START_NO_STOP);
+
+    // --- GPTimer Setup for Cooldown Delay ---
+    gptimer_config_t gptimer_config = {
+        .clk_src = GPTIMER_CLK_SRC_DEFAULT,
+        .direction = GPTIMER_COUNT_UP,
+        .resolution_hz = 1 * 1000 * 1000, // 1MHz, 1 tick = 1us
+    };
+    gptimer_new_timer(&gptimer_config, &gptimer);
+
+    gptimer_alarm_config_t alarm_config = {
+        .alarm_count = BEMF_MEASUREMENT_DELAY_US,
+        .reload_count = 0,
+        .flags.auto_reload_on_alarm = false,
+    };
+    gptimer_set_alarm_action(gptimer, &alarm_config);
+    gptimer_enable(gptimer);
+    // Note: gptimer is not started here. It will be started by the ETM.
+
+    // --- ADC Setup ---
+    adcAttachPin(g_bemf_a_pin);
+    adcAttachPin(g_bemf_b_pin);
+    analogReadResolution(12);
+
+    // --- ETM Setup for Hardware Triggering ---
+    mcpwm_etm_event_config_t mcpwm_event_config = { .event_type = MCPWM_TIMER_EVENT_FULL };
+    esp_etm_event_handle_t mcpwm_timer_event;
+    mcpwm_new_etm_event(timer, &mcpwm_event_config, &mcpwm_timer_event);
+
+    gptimer_etm_task_config_t gptimer_start_task_config = { .task_type = GPTIMER_ETM_TASK_START_COUNT };
+    esp_etm_task_handle_t gptimer_start_task;
+    gptimer_new_etm_task(gptimer, &gptimer_start_task_config, &gptimer_start_task);
+
+    gptimer_etm_event_config_t gptimer_event_config = { .event_type = GPTIMER_EVENT_ALARM };
+    esp_etm_event_handle_t gptimer_alarm_event;
+    gptimer_new_etm_event(gptimer, &gptimer_event_config, &gptimer_alarm_event);
+
+    // Placeholder for ADC ETM task - to be implemented when ADC ETM driver is available.
+    // For now, we will use a software ISR from the GPTimer.
+
+    gptimer_etm_task_config_t gptimer_stop_task_config = { .task_type = GPTIMER_ETM_TASK_STOP_COUNT };
+    esp_etm_task_handle_t gptimer_stop_task;
+    gptimer_new_etm_task(gptimer, &gptimer_stop_task_config, &gptimer_stop_task);
+
+    esp_etm_channel_config_t etm_config_1 = {};
+    esp_etm_channel_handle_t etm_channel_1;
+    esp_etm_new_channel(&etm_config_1, &etm_channel_1);
+    esp_etm_channel_connect(etm_channel_1, mcpwm_timer_event, gptimer_start_task);
+    esp_etm_channel_enable(etm_channel_1);
+
+    esp_etm_channel_config_t etm_config_3 = {};
+    esp_etm_channel_handle_t etm_channel_3;
+    esp_etm_new_channel(&etm_config_3, &etm_channel_3);
+    esp_etm_channel_connect(etm_channel_3, gptimer_alarm_event, gptimer_stop_task);
+    esp_etm_channel_enable(etm_channel_3);
+
+    // --- ADC Interrupt ---
+    // Since we cannot trigger the ADC directly from the ETM yet, we will
+    // use the GPTimer's alarm ISR to trigger the ADC manually.
+    gptimer_event_callbacks_t cbs = {
+        .on_alarm = gptimer_alarm_isr_handler,
+    };
+    gptimer_register_event_callbacks(gptimer, &cbs, nullptr);
+}
+
+static bool IRAM_ATTR gptimer_alarm_isr_handler(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_data)
+{
+    int bemf_a_val = analogRead(g_bemf_a_pin);
+    int bemf_b_val = analogRead(g_bemf_b_pin);
+    int measured_bemf = abs(bemf_a_val - bemf_b_val);
+
+    if (bemf_callback) {
+        bemf_callback(measured_bemf);
+    }
+
+    // Re-arm the timer
+    gptimer_set_raw_count(timer, 0);
+
+    return false;
+}
+
+void hal_motor_set_pwm(int duty_cycle, bool forward) {
+    uint32_t duty_ticks = (PWM_TIMER_RESOLUTION_HZ / PWM_FREQUENCY_HZ) * (duty_cycle / 255.0f);
+
+    if (forward) {
+        mcpwm_comparator_set_compare_value(comparator_a, duty_ticks);
+        mcpwm_comparator_set_compare_value(comparator_b, 0);
+    } else {
+        mcpwm_comparator_set_compare_value(comparator_a, 0);
+        mcpwm_comparator_set_compare_value(comparator_b, duty_ticks);
+    }
+}
+
+#endif // ARDUINO_ARCH_ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
 [platformio]
-default_envs = native_test
+default_envs = native_test, seeed_xiao_esp32c3, esp32_s2_saola, esp32_s3_devkit
 test_dir = test
 
 [env:native_test]
@@ -17,6 +17,22 @@ lib_deps =
     adafruit/Adafruit NeoPixel
     denyssene/SimpleKalmanFilter
 
+[env:esp32_s2_saola]
+platform = espressif32
+board = esp32-s2-saola-1
+framework = arduino
+lib_deps =
+    adafruit/Adafruit NeoPixel
+    denyssene/SimpleKalmanFilter
+
+[env:esp32_s3_devkit]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+lib_deps =
+    adafruit/Adafruit NeoPixel
+    denyssene/SimpleKalmanFilter
+
 [env:advanced_movement]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = seeed_xiao_rp2040
@@ -27,6 +43,14 @@ lib_deps =
     XDuinoRails
     adafruit/Adafruit NeoPixel
     mathertel/RotaryEncoder
+
+[env:seeed_xiao_esp32c3]
+platform = espressif32
+board = seeed_xiao_esp32c3
+framework = arduino
+lib_deps =
+    adafruit/Adafruit NeoPixel
+    denyssene/SimpleKalmanFilter
 
 [env:nucleo_f446re]
 platform = ststm32


### PR DESCRIPTION
This commit introduces a new Hardware Abstraction Layer (HAL) for the ESP32 family (C3, S2, S3), enabling the `xDuinoRails_MotorControl_bEMF` library to be used with these microcontrollers.

The implementation uses a high-precision, hardware-timed method for BEMF measurement. It leverages the ESP32's Event Task Matrix (ETM) to connect the MCPWM timer's 'peak' event to the start of a one-shot GPTimer. The GPTimer's alarm ISR is then triggered after a precise delay (e.g., 10µs), which in turn calls `analogRead()` to measure the BEMF. This ensures an accurate BEMF reading after the PWM cooldown period.

New build environments for the Seeed Studio XIAO ESP32-C3, ESP32-S2 Saola, and ESP32-S3 Devkit have also been added to the `platformio.ini` file to allow for easy compilation and testing of the new HAL.